### PR TITLE
Update esprima

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "escodegen": "^1.6.1",
-    "esprima": "^1.2.5"
+    "esprima": "^2.7.2"
   },
   "devDependencies": {
     "espower-loader": "^0.10.0",


### PR DESCRIPTION
Hello, the bundled version of esprima doesn’t support ES 2015.

After installing the updates all tests work as before. I’ve also tested it out on an actual program – works like a charm!
